### PR TITLE
Refactor: PocketBase API에 생성한 데이터 타입 선언

### DIFF
--- a/src/types/Locals.ts
+++ b/src/types/Locals.ts
@@ -1,0 +1,17 @@
+export interface LocalItem {
+  id: string;
+  collectionId: string;
+  collectionName: string;
+  created: string;
+  updated: string;
+  name: string;
+  image: string;
+}
+
+export interface Locals {
+  page: number;
+  perPage: number;
+  totalPages: number;
+  totalItems: number;
+  items: LocalItem[];
+}

--- a/src/types/MySchedule.ts
+++ b/src/types/MySchedule.ts
@@ -1,0 +1,39 @@
+interface Place {
+  address_name: string;
+  category_group_code: string;
+  category_group_name: string;
+  category_name: string;
+  distance: string;
+  id: string;
+  phone: string;
+  place_name: string;
+  place_url: string;
+  road_address_name: string;
+  x: string;
+  y: string;
+}
+
+export interface MyScheduleItem {
+  id: string;
+  collectionId: string;
+  collectionName: string;
+  created: string;
+  updated: string;
+  title: string;
+  username: string;
+  main: string | null;
+  place: string[] | null;
+  hotel: string[] | null;
+  start_date: string | null;
+  end_date: string | null;
+  places: Place[] | null;
+  hotels: Place[] | null;
+}
+
+export interface MySchedule {
+  page: number;
+  perPage: number;
+  totalPages: number;
+  totalItems: number;
+  items: MyScheduleItem[];
+}

--- a/src/types/Recommens.ts
+++ b/src/types/Recommens.ts
@@ -1,0 +1,26 @@
+export interface RecommenItem {
+  id: string;
+  collectionId: string;
+  collectionName: string;
+  created: string;
+  updated: string;
+  localName: string | null;
+  place: string;
+  image: string[];
+  address: string;
+  info: string | null;
+  rest: string | null;
+  active: string | null;
+  time: string | null;
+  url: string | null;
+  useremail: string[];
+  localMain: string;
+}
+
+export interface Recommens {
+  page: number;
+  perPage: number;
+  totalPages: number;
+  totalItems: number;
+  items: RecommenItem[];
+}

--- a/src/types/Travels.ts
+++ b/src/types/Travels.ts
@@ -1,0 +1,20 @@
+export interface TravelItem {
+  id: string;
+  collectionId: string;
+  collectionName: string;
+  created: string;
+  updated: string;
+  title: string;
+  image: string[];
+  text: string;
+  useremail: string[];
+  info: string;
+}
+
+export interface Travels {
+  page: number;
+  perPage: number;
+  totalPages: number;
+  totalItems: number;
+  items: TravelItem[];
+}


### PR DESCRIPTION
# 📌 관련 이슈
closed to #177 

## ✨ 작업 내용
- `Locals`, `MySchedule`, `Recommends`, `Travels` 타입 파일 생성하였습니다.
- **각 타입 내 `LocalItem`, `MyScheduleItem`, `RecommendItem`, `TravelItem` 작성** 하였습니다.
- 현재 **키-값 타입은 대부분 `string`** 로 설정되어 있습니다. 작업에 맞게 수정해주세요.

## ✅ 달성도
- 100%, 작업 완료하였습니다.

## 📸 레퍼런스
```ts
export interface TravelItem {
  id: string;
  collectionId: string;
  collectionName: string;
  created: string;
  updated: string;
  title: string;
  image: string[];
  text: string;
  useremail: string[];
  info: string;
}

export interface Travels {
  page: number;
  perPage: number;
  totalPages: number;
  totalItems: number;
  items: TravelItem[];
}

```

---

### 체크리스트

- [ ] 코드는 문제없이 빌드 및 실행됩니다.
- [x] 코드 스타일은 프로젝트 규칙을 따릅니다.
- [x] 새로운 기능은 테스트되었고, 기존 기능에 영향을 미치지 않습니다.
- [x] 관련사항을 이슈템플릿에 추가하였습니다.